### PR TITLE
support for specifying tls certificates as raw string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
     working_directory: /go/src/github.com/cybozu-go/etcdutil
     steps:
       - checkout
+      # TODO use go mod
+      - run: go get -v -t -d ./...
+      - run: (cd /go/src/github.com/coreos/etcd; git checkout v3.3.9)
       - run: go get -v -t -d ./...
       - run: test -z "$(goimports -d . | tee /dev/stderr)"
       - run: golint -set_exit_status ./...

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
@@ -27,9 +28,14 @@ func NewClient(c *Config) (*clientv3.Client, error) {
 
 	tlsCfg := &tls.Config{}
 	if len(c.TLSCA) != 0 {
-		rootCACert, err := ioutil.ReadFile(c.TLSCA)
-		if err != nil {
-			return nil, err
+		var rootCACert []byte
+		if _, err := os.Stat(c.TLSCA); err != nil {
+			rootCACert, err = ioutil.ReadFile(c.TLSCA)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			rootCACert = []byte(c.TLSCA)
 		}
 		rootCAs := x509.NewCertPool()
 		ok := rootCAs.AppendCertsFromPEM(rootCACert)
@@ -40,9 +46,24 @@ func NewClient(c *Config) (*clientv3.Client, error) {
 		cfg.TLS = tlsCfg
 	}
 	if len(c.TLSCert) != 0 && len(c.TLSKey) != 0 {
-		cert, err := tls.LoadX509KeyPair(c.TLSCert, c.TLSKey)
-		if err != nil {
-			return nil, err
+		_, certErr := os.Stat(c.TLSCert)
+		_, keyErr := os.Stat(c.TLSKey)
+		var cert tls.Certificate
+		if certErr == nil && keyErr == nil {
+			cert, err = tls.LoadX509KeyPair(c.TLSCert, c.TLSKey)
+			if err != nil {
+				return nil, err
+			}
+		} else if certErr != nil && keyErr != nil {
+			cert, err = tls.X509KeyPair([]byte(c.TLSCert), []byte(c.TLSKey))
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			if certErr == nil {
+				return nil, errors.New("tls-cert is a file, but tls-key is not")
+			}
+			return nil, errors.New("tls-key is a file, but tls-cert is not")
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 		cfg.TLS = tlsCfg

--- a/client.go
+++ b/client.go
@@ -29,7 +29,7 @@ func NewClient(c *Config) (*clientv3.Client, error) {
 	tlsCfg := &tls.Config{}
 	if len(c.TLSCA) != 0 {
 		var rootCACert []byte
-		if _, err := os.Stat(c.TLSCA); err != nil {
+		if _, err := os.Stat(c.TLSCA); err == nil {
 			rootCACert, err = ioutil.ReadFile(c.TLSCA)
 			if err != nil {
 				return nil, err

--- a/client.go
+++ b/client.go
@@ -29,7 +29,7 @@ func NewClient(c *Config) (*clientv3.Client, error) {
 	if len(c.TLSCAFile) != 0 || len(c.TLSCA) != 0 {
 		var rootCACert []byte
 		if len(c.TLSCAFile) != 0 {
-			rootCACert, err = ioutil.ReadFile(c.TLSCA)
+			rootCACert, err = ioutil.ReadFile(c.TLSCAFile)
 			if err != nil {
 				return nil, err
 			}

--- a/config.go
+++ b/config.go
@@ -22,11 +22,17 @@ type Config struct {
 	Username string `yaml:"username" json:"username" toml:"username"`
 	// Password is password for loging in to the etcd.
 	Password string `yaml:"password" json:"password" toml:"password"`
-	// TLSCA is root CA path or raw string.
+	// TLSCAFile is root CA path.
+	TLSCAFile string `yaml:"tls-ca-file" json:"tls-ca-file" toml:"tls-ca-file"`
+	// TLSCA is root CA raw string.
 	TLSCA string `yaml:"tls-ca" json:"tls-ca" toml:"tls-ca"`
-	// TLSCert is TLS client certificate path or raw string.
+	// TLSCertFile is TLS client certificate path.
+	TLSCertFile string `yaml:"tls-cert-file" json:"tls-cert-file" toml:"tls-cert-file"`
+	// TLSCert is TLS client certificate raw string.
 	TLSCert string `yaml:"tls-cert" json:"tls-cert" toml:"tls-cert"`
-	// TLSKey is TLS client private key path or raw string.
+	// TLSKeyFile is TLS client private key.
+	TLSKeyFile string `yaml:"tls-key-file" json:"tls-key-file" toml:"tls-key-file"`
+	// TLSKey is TLS client private key raw string.
 	TLSKey string `yaml:"tls-key" json:"tls-key" toml:"tls-key"`
 }
 

--- a/config.go
+++ b/config.go
@@ -22,11 +22,11 @@ type Config struct {
 	Username string `yaml:"username" json:"username" toml:"username"`
 	// Password is password for loging in to the etcd.
 	Password string `yaml:"password" json:"password" toml:"password"`
-	// TLSCA is root CA path.
+	// TLSCA is root CA path or raw string.
 	TLSCA string `yaml:"tls-ca" json:"tls-ca" toml:"tls-ca"`
-	// TLSCert is TLS client certificate path.
+	// TLSCert is TLS client certificate path or raw string.
 	TLSCert string `yaml:"tls-cert" json:"tls-cert" toml:"tls-cert"`
-	// TLSKey is TLS client private key path.
+	// TLSKey is TLS client private key path or raw string.
 	TLSKey string `yaml:"tls-key" json:"tls-key" toml:"tls-key"`
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -47,17 +47,17 @@ password: testpass
 		},
 		{
 			source: `
-tls-ca: ca.crt
-tls-cert: client.crt
-tls-key: client.key
+tls-ca-file: ca.crt
+tls-cert-file: client.crt
+tls-key-file: client.key
 `,
 			expected: Config{
-				Endpoints: DefaultEndpoints,
-				Timeout:   DefaultTimeout,
-				Prefix:    prefix,
-				TLSCA:     "ca.crt",
-				TLSCert:   "client.crt",
-				TLSKey:    "client.key",
+				Endpoints:   DefaultEndpoints,
+				Timeout:     DefaultTimeout,
+				Prefix:      prefix,
+				TLSCAFile:   "ca.crt",
+				TLSCertFile: "client.crt",
+				TLSKeyFile:  "client.key",
 			},
 		},
 	}
@@ -117,18 +117,18 @@ func testEtcdConfigJSON(t *testing.T) {
 		{
 			source: `
 {
-    "tls-ca": "ca.crt",
-    "tls-cert": "client.crt",
-    "tls-key": "client.key"
+    "tls-ca-file": "ca.crt",
+    "tls-cert-file": "client.crt",
+    "tls-key-file": "client.key"
 }
 `,
 			expected: Config{
-				Endpoints: DefaultEndpoints,
-				Timeout:   DefaultTimeout,
-				Prefix:    prefix,
-				TLSCA:     "ca.crt",
-				TLSCert:   "client.crt",
-				TLSKey:    "client.key",
+				Endpoints:   DefaultEndpoints,
+				Timeout:     DefaultTimeout,
+				Prefix:      prefix,
+				TLSCAFile:   "ca.crt",
+				TLSCertFile: "client.crt",
+				TLSKeyFile:  "client.key",
 			},
 		},
 	}
@@ -179,17 +179,17 @@ password = "testpass"
 		},
 		{
 			source: `
-tls-ca = "ca.crt"
-tls-cert = "client.crt"
-tls-key = "client.key"
+tls-ca-file = "ca.crt"
+tls-cert-file = "client.crt"
+tls-key-file = "client.key"
 `,
 			expected: Config{
-				Endpoints: DefaultEndpoints,
-				Timeout:   DefaultTimeout,
-				Prefix:    prefix,
-				TLSCA:     "ca.crt",
-				TLSCert:   "client.crt",
-				TLSKey:    "client.key",
+				Endpoints:   DefaultEndpoints,
+				Timeout:     DefaultTimeout,
+				Prefix:      prefix,
+				TLSCAFile:   "ca.crt",
+				TLSCertFile: "client.crt",
+				TLSKeyFile:  "client.key",
 			},
 		},
 	}


### PR DESCRIPTION
if the specified path exists, it will be used as file path, if not as raw string.