### PR TITLE
Remove http://127.0.0.1:4001 from the default endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ tls-key: |
 
 ### Command-line flags
 
-Name             | Default                                       | Description
----------------- | --------------------------------------------- | -----------
-`etcd-endpoints` | `http://127.0.0.1:2379,http://127.0.0.1:4001` | comma-separated URLs of the backend etcd
-`etcd-password`  |                                               | password for etcd authentication
-`etcd-prefix`    |                                               | prefix for etcd keys
-`etcd-timeout`   | `2s`                                          | dial timeout duration to etcd
-`etcd-tls-ca`    |                                               | Path to CA bundle used to verify etcd server certificates.
-`etcd-tls-cert`  |                                               | Path to client certificate file of an etcd user.
-`etcd-tls-key`   |                                               | Path to private key file of an etcd user.
-`etcd-username`  |                                               | username for etcd authentication
+Name             | Default                 | Description
+---------------- | ----------------------- | -----------
+`etcd-endpoints` | `http://127.0.0.1:2379` | comma-separated URLs of the backend etcd
+`etcd-password`  |                         | password for etcd authentication
+`etcd-prefix`    |                         | prefix for etcd keys
+`etcd-timeout`   | `2s`                    | dial timeout duration to etcd
+`etcd-tls-ca`    |                         | Path to CA bundle used to verify etcd server certificates.
+`etcd-tls-cert`  |                         | Path to client certificate file of an etcd user.
+`etcd-tls-key`   |                         | Path to private key file of an etcd user.
+`etcd-username`  |                         | username for etcd authentication
 
 Usage
 -----

--- a/config.go
+++ b/config.go
@@ -7,7 +7,7 @@ const (
 
 var (
 	// DefaultEndpoints is default etcd servers.
-	DefaultEndpoints = []string{"http://127.0.0.1:2379", "http://127.0.0.1:4001"}
+	DefaultEndpoints = []string{"http://127.0.0.1:2379"}
 )
 
 // Config represents configuration parameters to access etcd.

--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,7 @@ To read parameters from YAML (or JSON):
 To read parameters from command-line flags:
 
     import (
-        "flags"
+        "flag"
 
         "github.com/cybozu-go/etcdutil"
     )


### PR DESCRIPTION
Port 4001 was for etcd v2 protocol.

For v3, the default endpoints are only :2379 as follows.

    $ ETCDCTL_API=3 etcdctl -h | grep endpoints=
          --endpoints=[127.0.0.1:2379]              gRPC endpoints