### PR TITLE
Work around etcd bug #9949.

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,8 +18,13 @@ func NewClient(c *Config) (*clientv3.Client, error) {
 		return nil, err
 	}
 
+	// workaround for https://github.com/etcd-io/etcd/issues/9949
+	endpoints := make([]string, len(c.Endpoints))
+	copy(endpoints, c.Endpoints)
+	reorderEndpoints(endpoints, timeout)
+
 	cfg := clientv3.Config{
-		Endpoints:   c.Endpoints,
+		Endpoints:   endpoints,
 		DialTimeout: timeout,
 		Username:    c.Username,
 		Password:    c.Password,

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,13 @@ require (
 	github.com/coreos/go-semver v0.2.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20181004131557-b14d3eb023cc // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/cybozu-go/log v1.5.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4 // indirect
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
+	github.com/google/go-cmp v0.2.0
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/coreos/go-systemd v0.0.0-20181004131557-b14d3eb023cc h1:EDHXXD9U9N6r9
 github.com/coreos/go-systemd v0.0.0-20181004131557-b14d3eb023cc/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cybozu-go/log v1.5.0 h1:cjLr+pNga4NL5sj5vnnG00xKmKXSWx0grQQ4LnV1Ris=
+github.com/cybozu-go/log v1.5.0/go.mod h1:zpfovuCgUx+a/ErvQrThoT+/z1RVQoLDOf95wkBeRiw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
@@ -34,6 +36,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCydnIczKteheJEzHRToSGK3Bnlw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -53,6 +57,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0 h1:1921Yw9Gc3iSc4VQh3PIoOqgPCZS7G/4xQNVUp8Mda8=

--- a/reorder.go
+++ b/reorder.go
@@ -1,0 +1,43 @@
+package etcdutil
+
+import (
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/cybozu-go/log"
+)
+
+// reorderEndpoints work around etcd/issues/9949.
+func reorderEndpoints(endpoints []string, timeout time.Duration) {
+	dialer := net.Dialer{
+		Timeout: timeout,
+	}
+
+	for i, endpoint := range endpoints {
+		addr := endpoint
+		u, err := url.Parse(endpoint)
+		if err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+			if u.Port() == "" {
+				// http and https is available even with CGO_ENABLED=0.
+				// https://golang.org/src/net/lookup.go#L44
+				addr = net.JoinHostPort(u.Host, u.Scheme)
+			} else {
+				addr = u.Host
+			}
+		}
+		c, err := dialer.Dial("tcp", addr)
+		if err != nil {
+			continue
+		}
+		c.Close()
+
+		endpoints[i] = endpoints[0]
+		endpoints[0] = endpoint
+		return
+	}
+
+	log.Warn("no etcd endpoint can be connected", map[string]interface{}{
+		"endpoints": endpoints,
+	})
+}

--- a/reorder_test.go
+++ b/reorder_test.go
@@ -1,0 +1,132 @@
+package etcdutil
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	endpoints = []string{
+		"localhost:80",
+		"localhost:443",
+		"localhost:12359",
+	}
+)
+
+func listen(t *testing.T) []net.Listener {
+	listeners := make([]net.Listener, len(endpoints))
+	for i, addr := range endpoints {
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		listeners[i] = l
+		go func() {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}()
+	}
+	return listeners
+}
+
+func TestReorder(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("need to run as root")
+	}
+
+	listeners := listen(t)
+	defer func() {
+		for _, l := range listeners {
+			l.Close()
+		}
+	}()
+
+	timeout := time.Millisecond * 100
+
+	t1 := []string{
+		"https://localhost:23456",
+		"http://localhost",
+		"https://localhost",
+	}
+	reorderEndpoints(t1, timeout)
+	if !cmp.Equal(t1, []string{
+		"http://localhost",
+		"https://localhost:23456",
+		"https://localhost",
+	}) {
+		t.Error("t1 is not reordered correctly", t1)
+	}
+
+	t2 := []string{
+		"https://localhost:23456",
+		"https://localhost",
+		"http://localhost",
+	}
+	reorderEndpoints(t2, timeout)
+	if !cmp.Equal(t2, []string{
+		"https://localhost",
+		"https://localhost:23456",
+		"http://localhost",
+	}) {
+		t.Error("t2 is not reordered correctly", t2)
+	}
+
+	t3 := []string{
+		"https://localhost",
+		"http://localhost",
+		"https://localhost:23456",
+	}
+	reorderEndpoints(t3, timeout)
+	if !cmp.Equal(t3, []string{
+		"https://localhost",
+		"http://localhost",
+		"https://localhost:23456",
+	}) {
+		t.Error("t3 should not be reordered", t3)
+	}
+
+	t4 := []string{
+		"http://localhost:9998",
+		"https://localhost:12359",
+		"http://localhost",
+	}
+	reorderEndpoints(t4, timeout)
+	if !cmp.Equal(t4, []string{
+		"https://localhost:12359",
+		"http://localhost:9998",
+		"http://localhost",
+	}) {
+		t.Error("t4 is not reordered correctly", t4)
+	}
+
+	t5 := []string{
+		"localhost:13333",
+		"localhost:12359",
+	}
+	reorderEndpoints(t5, timeout)
+	if !cmp.Equal(t5, []string{
+		"localhost:12359",
+		"localhost:13333",
+	}) {
+		t.Error("t5 is not reordered correctly", t5)
+	}
+
+	t6 := []string{
+		"localhost:13333",
+		"localhost:13334",
+	}
+	reorderEndpoints(t6, timeout)
+	if !cmp.Equal(t6, []string{
+		"localhost:13333",
+		"localhost:13334",
+	}) {
+		t.Error("t6 should not be reordered", t6)
+	}
+}


### PR DESCRIPTION
etcd bug #9949 blocks clients if the first endpoint is down.
To work around it, this commit reorders the list of endpoints
before creating *clientv3.Client by moving the first available
endpoint to head of the endpoint list.

Closes #4.